### PR TITLE
fix that users without post permission have reply/attach buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ To see every change with descriptions aimed at developers, see
 As a continuously updated web app, Coauthor uses dates
 instead of version numbers.
 
+## 2021-09-10
+
+* Fix accidental Reply buttons when user has no Post permission
+  (at the bottom of message with children).
+  [[#585](https://github.com/edemaine/coauthor/pull/585)]
+
+## 2021-07-07
+
+* Improve automatic image reloading when file gets replaced.
+  [[#163](https://github.com/edemaine/coauthor/issues/163)]
+
 ## 2021-06-16
 
 * Tweak dark-mode scrollbar colors on Firefox mode so they don't disappear

--- a/client/message.coffee
+++ b/client/message.coffee
@@ -2606,7 +2606,9 @@ export WrappedSubmessage = React.memo ({message, read}) ->
               }
             </div>
             <div className="panel-body panel-secondbody hidden-print clearfix">
-              <ReplyButtons message={message}/>
+              {if can.reply
+                <ReplyButtons message={message}/>
+              }
               <span className="message-title">
                 <a className="btn btn-default btn-xs linkToTop" aria-label="Top" href="##{message._id}">
                   <span className="fas fa-caret-up"/>

--- a/client/message.coffee
+++ b/client/message.coffee
@@ -2606,7 +2606,7 @@ export WrappedSubmessage = React.memo ({message, read}) ->
               }
             </div>
             <div className="panel-body panel-secondbody hidden-print clearfix">
-              {if can.reply
+              {if can.reply and not read
                 <ReplyButtons message={message}/>
               }
               <span className="message-title">


### PR DESCRIPTION
The buttons at the top were already hidden for such users; this hides the bottom ones. The buttons don't do anything since the user isn't allowed to post.