### PR TITLE
Codex/implement issue #490 from coauthor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ This file describes significant changes to Coauthor to an audience of
 both everyday users and administrators running their own Coauthor server.
 To see every change with descriptions aimed at developers, see
 [the Git log](https://github.com/edemaine/coauthor/commits/main).
+
 As a continuously updated web app, Coauthor uses dates
 instead of version numbers.
+
+## 2025-06-18
+
+* Paste image from clipboard creates an attached file and embeds it in the message
+  [[#490](https://github.com/edemaine/coauthor/issues/490)]
 
 ## 2025-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ instead of version numbers.
 
 ## 2025-06-18
 
-* Paste image from clipboard creates an attached file and embeds it in the message
+* Pasting an image directly into the editor now uploads it as an attached file
+  and embeds it at the cursor location
   [[#490](https://github.com/edemaine/coauthor/issues/490)]
 
 ## 2025-06-13

--- a/client/message.coffee
+++ b/client/message.coffee
@@ -769,6 +769,47 @@ export MessageEditor = React.memo ({message, setEditBody, setEditDirty, tabindex
         paste = null
         editor.on 'paste', (cm, e) ->
           paste = null
+          files = []
+          for item in e.clipboardData?.items ? []
+            if item.kind == 'file' and /^image\//.test item.type
+              file = item.getAsFile()
+              files.push file if file?
+          if files.length
+            e.preventDefault()
+            callbacks = {}
+            called = 0
+            insertPos = editor.getCursor()
+            defaultPublished = autopublish()
+            defaultPublished and= Boolean message.published
+            defaultDeleted = Boolean message.deleted
+            for file, i in files
+              do (i) ->
+                file.callback = (file2, done) ->
+                  callbacks[i] = ->
+                    start = _.clone insertPos
+                    Meteor.call 'messageNew', message.group, message._id, null,
+                      file: file2.uniqueIdentifier
+                      deleted: defaultDeleted
+                      published: defaultPublished
+                      finished: true
+                    , (error, result) ->
+                        if error
+                          console.error error
+                        else if result
+                          replacement = embedFile result, true, 'image'
+                          cm.replaceRange replacement, start
+                          insertPos = editor.getCursor()
+                        else
+                          console.error 'messageNew did not return message ID -- not authorized?'
+                        done()
+                  while callbacks[called]?
+                    callbacks[called]()
+                    called += 1
+                file.metadata =
+                  group: message.group
+                  root: message2root message
+                Files.resumable.addFile file, e
+            return
           if pasteHTML and 'text/html' in e.clipboardData.types
             paste = e.clipboardData.getData 'text/html'
             .replace /<!--.*?-->/g, ''


### PR DESCRIPTION
## Summary
- allow pasting image files directly in the message editor
- automatically upload the image as a child message and embed it at the cursor
- document the new behaviour in the changelog

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685956f1fef88322a3b67b5dcad7d174